### PR TITLE
슬랙 메시지 전송·저장·조회 기능 구현

### DIFF
--- a/src/main/java/org/pokeherb/slackservice/application/service/MessageService.java
+++ b/src/main/java/org/pokeherb/slackservice/application/service/MessageService.java
@@ -1,0 +1,80 @@
+package org.pokeherb.slackservice.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.pokeherb.slackservice.domain.MessageSend;
+import org.pokeherb.slackservice.domain.Message;
+import org.pokeherb.slackservice.domain.MessageRepository;
+import org.pokeherb.slackservice.domain.MessageStatus;
+import org.pokeherb.slackservice.domain.exception.SlackErrorCode;
+import org.pokeherb.slackservice.global.infrastructure.exception.CustomException;
+import org.pokeherb.slackservice.presentation.dto.SlackDetailResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+    private final MessageSend messageSend;
+    private final MessageRepository repository;
+
+    @Transactional
+    public UUID sendAndSave(UUID receiverUserId, String messageText, String slackUserId) {
+        boolean success;
+        String errorMessage = null;
+
+        try {
+            // 슬랙 메시지 전송
+            success = messageSend.send(List.of(slackUserId),  messageText);
+        } catch (Exception e) {
+            throw new CustomException(SlackErrorCode.SLACK_API_ERROR);
+        }
+
+        MessageStatus status = success ? MessageStatus.SUCCESS : MessageStatus.FAILED;
+
+        Message slackMessage = Message.builder()
+                .receiverUserId(receiverUserId)
+                .message(messageText)
+                .status(status)
+                .errorMessage(errorMessage)
+                .sentAt(LocalDateTime.now())
+                .build();
+
+        repository.save(slackMessage);
+
+        return slackMessage.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public SlackDetailResponse getDetails(UUID id) {
+        Message message = repository.findById(id).orElseThrow(()
+                -> new CustomException(SlackErrorCode.MESSAGE_NOT_FOUND));
+
+        return new SlackDetailResponse(
+                message.getId(),
+                message.getReceiverUserId(),
+                message.getMessage(),
+                message.getStatus(),
+                message.getErrorMessage(),
+                message.getSentAt()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<SlackDetailResponse> getAll() {
+        return repository.findAll().stream()
+                .map(m -> new SlackDetailResponse(
+                        m.getId(),
+                        m.getReceiverUserId(),
+                        m.getMessage(),
+                        m.getStatus(),
+                        m.getErrorMessage(),
+                        m.getSentAt()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/org/pokeherb/slackservice/domain/Message.java
+++ b/src/main/java/org/pokeherb/slackservice/domain/Message.java
@@ -1,0 +1,46 @@
+package org.pokeherb.slackservice.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "P_SLACK_MESSAGE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID receiverUserId;
+
+    @Lob
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    private MessageStatus status;
+
+    private String errorMessage;
+
+    @Column(nullable = false)
+    private LocalDateTime sentAt;
+
+    @Builder
+    public Message(UUID id, UUID receiverUserId, String message, MessageStatus status,
+                   String errorMessage, LocalDateTime sentAt) {
+        this.id = id;
+        this.receiverUserId = receiverUserId;
+        this.message = message;
+        this.status = status;
+        this.errorMessage = errorMessage;
+        this.sentAt = sentAt;
+    }
+}

--- a/src/main/java/org/pokeherb/slackservice/domain/MessageRepository.java
+++ b/src/main/java/org/pokeherb/slackservice/domain/MessageRepository.java
@@ -1,0 +1,12 @@
+package org.pokeherb.slackservice.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+/**
+ * 슬랙 메시지 전송 이력 저장 및 조회 Repository
+ */
+public interface MessageRepository extends JpaRepository<Message, UUID> {
+
+}

--- a/src/main/java/org/pokeherb/slackservice/domain/MessageStatus.java
+++ b/src/main/java/org/pokeherb/slackservice/domain/MessageStatus.java
@@ -1,0 +1,6 @@
+package org.pokeherb.slackservice.domain;
+
+public enum MessageStatus {
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/org/pokeherb/slackservice/domain/exception/SlackErrorCode.java
+++ b/src/main/java/org/pokeherb/slackservice/domain/exception/SlackErrorCode.java
@@ -1,0 +1,17 @@
+package org.pokeherb.slackservice.domain.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.pokeherb.slackservice.global.infrastructure.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SlackErrorCode implements BaseErrorCode {
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "SLACK404", "해당 슬랙 메시지를 찾을 수 없습니다."),
+    SLACK_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SLACK500", "슬랙 API 호출 중 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/pokeherb/slackservice/presentation/controller/SlackMessageController.java
+++ b/src/main/java/org/pokeherb/slackservice/presentation/controller/SlackMessageController.java
@@ -1,0 +1,49 @@
+package org.pokeherb.slackservice.presentation.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pokeherb.slackservice.application.service.MessageService;
+import org.pokeherb.slackservice.presentation.dto.SlackDetailResponse;
+import org.pokeherb.slackservice.presentation.dto.SlackSendRequest;
+import org.pokeherb.slackservice.presentation.dto.SlackSendResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class SlackMessageController {
+
+    private final MessageService messageService;
+
+    // 로그인한 모든 사용자 발송 가능
+    @PostMapping("messages")
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasAnyRole('...')")
+    public SlackSendResponse send(@RequestBody SlackSendRequest request) {
+        UUID id = messageService.sendAndSave(
+                request.receiverUserId(),
+                request.message(),
+                request.slackUserId()
+        );
+        return new SlackSendResponse(id);
+    }
+
+    // 조회 및 검색 (관리자만)
+
+    @GetMapping("/{messageId}")
+    @PreAuthorize("hasRole('MASTER')")
+    public SlackDetailResponse getOne(@PathVariable UUID messageId) {
+        return messageService.getDetails(messageId);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('MASTER')")
+    public List<SlackDetailResponse> getAll() {
+        return messageService.getAll();
+    }
+}

--- a/src/main/java/org/pokeherb/slackservice/presentation/dto/SlackDetailResponse.java
+++ b/src/main/java/org/pokeherb/slackservice/presentation/dto/SlackDetailResponse.java
@@ -1,0 +1,15 @@
+package org.pokeherb.slackservice.presentation.dto;
+
+import org.pokeherb.slackservice.domain.MessageStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SlackDetailResponse(
+        UUID id,
+        UUID receiverUserId,
+        String message,
+        MessageStatus status,
+        String errorMessage,
+        LocalDateTime sentAt
+) {}

--- a/src/main/java/org/pokeherb/slackservice/presentation/dto/SlackSendRequest.java
+++ b/src/main/java/org/pokeherb/slackservice/presentation/dto/SlackSendRequest.java
@@ -1,0 +1,9 @@
+package org.pokeherb.slackservice.presentation.dto;
+
+import java.util.UUID;
+
+public record SlackSendRequest(
+        UUID receiverUserId,
+        String slackUserId,
+        String message
+) {}

--- a/src/main/java/org/pokeherb/slackservice/presentation/dto/SlackSendResponse.java
+++ b/src/main/java/org/pokeherb/slackservice/presentation/dto/SlackSendResponse.java
@@ -1,0 +1,7 @@
+package org.pokeherb.slackservice.presentation.dto;
+
+import java.util.UUID;
+
+public record SlackSendResponse(
+        UUID id
+) {}


### PR DESCRIPTION
- 제목 : feat(#3): 슬랙 메시지 전송·저장·조회 기능 구현

## 🔘Part

- Message
- MessageStatus
- MessageRepository
- MessageService
- SlackErrorCode
- SlackMessageController
- SlackDetailResponse
- SlackSendRequest
- SlackSendResponse

## 🔎 작업 내용

- Message: 메시지 전송 이력을 저장하는 JPA 엔티티 추가
- MessageStatus: 메시지 전송 결과 상태 enum 추가
- MessageRepository: 메시지 엔티티 JPA 레포지토리 추가
- MessageService: 메시지 전송 후 결과와 이력을 저장하는 서비스 로직 구현
- SlackErrorCode: 슬랙 전용 에러 코드 정의
- SlackMessageController: 단건 조회 및 전체 조회 API 추가
- SlackDetailResponse: 메시지 상세 조회 응답 DTO 추가
- SlackSendRequest: 메시지 전송 요청 DTO 정의
- SlackSendResponse: 메시지 전송 응답 DTO 정의


## 🔧 점검 내용

- 관리자가 유의해서 확인해야할 내용이
- 있다면 적어주세요

## ➕ 이슈 링크

- [#3]