### PR TITLE
RabbitMQ 기반 Slack 메시지 비동기 처리 기능 추가

### DIFF
--- a/src/main/java/org/pokeherb/slackservice/infrastructure/messaging/RabbitConsumer.java
+++ b/src/main/java/org/pokeherb/slackservice/infrastructure/messaging/RabbitConsumer.java
@@ -1,23 +1,35 @@
 package org.pokeherb.slackservice.infrastructure.messaging;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pokeherb.slackservice.infrastructure.messaging.handler.SlackEventHandler;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class RabbitConsumer {
 
+    private final Map<String, SlackEventHandler> handlers;
+
     @RabbitListener(queues = "slack")
-    public void handleMessage(Message message) {
+    public void listen(Message message) {
         String routingKey = message.getMessageProperties().getReceivedRoutingKey();
         String payload = new String(message.getBody(), StandardCharsets.UTF_8);
 
-        switch (routingKey) {
-            case "slack.created.order":
-                // 주문 생성 이벤트 처리
-                System.out.println(payload);
+        log.info("Received MQ message - routingKey={}, payload={}", routingKey, payload);
+
+        SlackEventHandler handler = handlers.get(routingKey);
+        if (handler == null) {
+            log.warn("Unhandled routingKey: {}", routingKey);
+            return;
         }
+
+        handler.handle(payload);
     }
 }

--- a/src/main/java/org/pokeherb/slackservice/infrastructure/messaging/event/SlackEvent.java
+++ b/src/main/java/org/pokeherb/slackservice/infrastructure/messaging/event/SlackEvent.java
@@ -1,0 +1,37 @@
+package org.pokeherb.slackservice.infrastructure.messaging.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.pokeherb.slackservice.application.service.MessageService;
+import org.pokeherb.slackservice.infrastructure.messaging.handler.AbstractSlackEventHandler;
+import org.pokeherb.slackservice.presentation.dto.SlackSendRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component("slack.create")
+public class SlackEvent extends AbstractSlackEventHandler {
+
+    private final MessageService messageService;
+
+    public SlackEvent(
+            com.fasterxml.jackson.databind.ObjectMapper objectMapper,
+            MessageService messageService
+    ) {
+        super(objectMapper);
+        this.messageService = messageService;
+    }
+
+    public void handle(String payload) {
+        // 공통 메서드로 JSON → DTO 변환
+        SlackSendRequest dto =
+                readPayload(payload, SlackSendRequest.class);
+
+        UUID receiverUserId = dto.receiverUserId();
+        String messageText = dto.message();
+        String slackUserId = dto.slackUserId();
+
+        // 도메인 서비스 호출
+        messageService.sendAndSave(receiverUserId, messageText, slackUserId);
+    }
+}

--- a/src/main/java/org/pokeherb/slackservice/infrastructure/messaging/handler/AbstractSlackEventHandler.java
+++ b/src/main/java/org/pokeherb/slackservice/infrastructure/messaging/handler/AbstractSlackEventHandler.java
@@ -1,0 +1,24 @@
+package org.pokeherb.slackservice.infrastructure.messaging.handler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pokeherb.slackservice.global.infrastructure.exception.CustomException;
+import org.pokeherb.slackservice.infrastructure.exception.RabbitErrorCode;
+
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractSlackEventHandler implements SlackEventHandler {
+
+    protected final ObjectMapper objectMapper;
+
+    protected <T> T readPayload(String payload, Class<T> type) {
+        try {
+            return objectMapper.readValue(payload, type);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse event payload: {}", payload, e);
+            throw new CustomException(RabbitErrorCode.RABBIT_JSON_PROCESSING_FAILED);
+        }
+    }
+}

--- a/src/main/java/org/pokeherb/slackservice/infrastructure/messaging/handler/SlackEventHandler.java
+++ b/src/main/java/org/pokeherb/slackservice/infrastructure/messaging/handler/SlackEventHandler.java
@@ -1,0 +1,5 @@
+package org.pokeherb.slackservice.infrastructure.messaging.handler;
+
+public interface SlackEventHandler {
+    void handle(String payload);
+}


### PR DESCRIPTION
- 제목 : feat(#7): RabbitMQ 기반 Slack 메시지 비동기 처리 기능 추가

## 🔘Part

- SlackEventHandler
- AbstractSlackEventHandler
- SlackEvent
- RabbitConsumer

## 🔎 작업 내용

- SlackEventHandler, AbstractSlackEventHandler: 공통 이벤트 핸들러 구조 정의
- SlackEvent: SlackSendRequest 파싱 후 MessageService.sendAndSave 호출
- RabbitConsumer: slack 큐 메시지 수신 및 routingKey 기반 핸들러 위임 처리


## 🔧 점검 내용

- 관리자가 유의해서 확인해야할 내용이
- 있다면 적어주세요

## ➕ 이슈 링크

- [#7]